### PR TITLE
292-endpoint-to-purge-old-members

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17536,7 +17536,7 @@ packages:
       queue-tick: 1.0.1
       text-decoder: 1.2.0
     optionalDependencies:
-      bare-events: 2.2.2
+      bare-events: 2.5.0
     dev: true
     optional: true
 

--- a/src/app/api/users/[userId]/membership/approve/route.ts
+++ b/src/app/api/users/[userId]/membership/approve/route.ts
@@ -25,7 +25,7 @@ export const PATCH = adminRouteWrapper(
 
     const [user] = await db
       .update(users)
-      .set({ verified: true, prepaidSessions })
+      .set({ verified: true, prepaidSessions, member: true })
       .where(eq(users.id, userId))
       .returning();
 

--- a/src/app/api/users/demoteall/route.ts
+++ b/src/app/api/users/demoteall/route.ts
@@ -10,7 +10,7 @@ export const PATCH = adminRouteWrapper(async (_req: NextRequest) => {
   // We only want to update the membership field to keep their verification status(returning).
   await db
     .update(users)
-    .set({ member: false })
+    .set({ member: false, prepaidSessions: 0 })
     .where(ne(users.role, roleEnum.enumValues[0]))
     // .where(and(eq(users.member, true), ne(users.role, roleEnum.enumValues[0])))
     .catch((error) => {


### PR DESCRIPTION
Update approve and demoteall routes

* Approve now gives casuals membership

* Demote all now sets all members and casuals to member and removes any prepaid sessions.
  * Doesn't apply towards admin